### PR TITLE
Настройка и запуск парсера woo

### DIFF
--- a/scraper/main.py
+++ b/scraper/main.py
@@ -206,6 +206,11 @@ def push_product(profile: str = typer.Option(..., "--profile"), url: str = typer
                     vp = {"attributes": [{"id": var_attr_id, "option": opt}]}
                     # всегда создаём/обновляем manage_stock=false, чтобы не упиралось в остатки
                     vp["manage_stock"] = False
+                    # если у родителя есть общий статус — передадим его как fallback
+                    if getattr(product, "stock_status", None) in ("instock", "outofstock") and not (v and getattr(v, "stock_status", None)):
+                        vp["stock_status"] = product.stock_status
+                    if v and getattr(v, "stock_status", None) in ("instock", "outofstock"):
+                        vp["stock_status"] = v.stock_status
                     price = None
                     if v and v.regular_price is not None:
                         price = v.regular_price

--- a/scraper/models.py
+++ b/scraper/models.py
@@ -10,6 +10,7 @@ class Variation(BaseModel):
     sku: str
     regular_price: float
     sale_price: Optional[float] = None
+    stock_status: Optional[Literal["instock", "outofstock"]] = None
     stock_quantity: Optional[int] = None
     attributes: Dict[str, str] = Field(default_factory=dict)
     image_url: Optional[str] = None
@@ -29,5 +30,6 @@ class Product(BaseModel):
     type: Literal["simple", "variable"] = "simple"
     regular_price: Optional[float] = None
     sale_price: Optional[float] = None
+    stock_status: Optional[Literal["instock", "outofstock"]] = None
     stock_quantity: Optional[int] = None
     variations: List[Variation] = Field(default_factory=list)

--- a/scraper/transform.py
+++ b/scraper/transform.py
@@ -37,6 +37,9 @@ def to_woo_product_payload(product: Product, status: str = "draft") -> dict:
             payload["regular_price"] = f"{product.regular_price:.2f}"
         if product.sale_price is not None:
             payload["sale_price"] = f"{product.sale_price:.2f}"
+        # Статус наличия
+        if getattr(product, "stock_status", None) in ("instock", "outofstock"):
+            payload["stock_status"] = product.stock_status
         if product.stock_quantity is not None:
             payload["manage_stock"] = True
             payload["stock_quantity"] = product.stock_quantity

--- a/scraper/wc.py
+++ b/scraper/wc.py
@@ -90,6 +90,10 @@ class WooClient:
                         if v.get(fld) != new_val:
                             update[fld] = new_val
                             need_update = True
+                # stock_status
+                if p.get("stock_status") in ("instock", "outofstock") and p.get("stock_status") != v.get("stock_status"):
+                    update["stock_status"] = p.get("stock_status")
+                    need_update = True
                 if p.get("image") and p["image"].get("src"):
                     img_src = p["image"]["src"]
                     cur_src = (v.get("image") or {}).get("src")


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Sanitize variation attribute values and add stock status parsing for products and variations to fix incorrect data and enable proper stock synchronization.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, variation attribute values could incorrectly include "Немає в наявності" (Out of stock) text due to broad text extraction. This PR refines attribute value parsing to only extract relevant text from `.modification__button` elements and sanitizes it. Additionally, it introduces logic to detect product and variation stock status based on the `.product-header__availability` element and map it to WooCommerce's `stock_status` field.

---
<a href="https://cursor.com/background-agent?bcId=bc-e96019e5-90e0-4cf2-ae2e-5d4e6868f120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e96019e5-90e0-4cf2-ae2e-5d4e6868f120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

