### PR TITLE
Настройка и запуск парсера Woo

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
+addopts = -q
+[pytest]
 pythonpath = .

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-addopts = -q
-[pytest]
-pythonpath = .

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 import os
 import sys
 
-
 def pytest_sessionstart(session):
     project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
     if project_root not in sys.path:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+import os
+import sys
+
+
+def pytest_sessionstart(session):
+    # Обеспечиваем импорт пакета scraper при запуске pytest из корня
+    project_root = os.path.dirname(os.path.abspath(__file__))
+    project_root = os.path.abspath(os.path.join(project_root, os.pardir))
+    if project_root not in sys.path:
+        sys.path.insert(0, project_root)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,6 @@ import sys
 
 
 def pytest_sessionstart(session):
-    # Обеспечиваем импорт пакета scraper при запуске pytest из корня
-    project_root = os.path.dirname(os.path.abspath(__file__))
-    project_root = os.path.abspath(os.path.join(project_root, os.pardir))
+    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
     if project_root not in sys.path:
         sys.path.insert(0, project_root)


### PR DESCRIPTION
Fix `ModuleNotFoundError` for `scraper` module during `pytest` execution.

Previously, `pytest` failed to import project modules because the project root was not in `sys.path`. This PR configures `pytest` to correctly resolve module imports by adding the project root to `pythonpath`.

---
<a href="https://cursor.com/background-agent?bcId=bc-e6fdbc16-bfd0-425d-b43d-96d0eaceff37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e6fdbc16-bfd0-425d-b43d-96d0eaceff37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

